### PR TITLE
Add MacOS/Linux support to start GRemoteFull

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The package consists of the software(Arduino firmware and GRemote), structure as
 4. Open GCodepraser->GCodeParser.ino by Arduino IDE. Click Tools->Serial Ports, choose COM XX (Not COM1 and COM2). Click Tools->Boards, choose Arduino Leonardo. At last, click "upload" button on the right-top corner.
                                                                                   [![alt text](images/Upload.png "Upload program to Me Baseboard")](https://raw.githubusercontent.com/Makeblock-official/XY-Plotter-2.0/master/images/Upload.png)
 
-5. Close Arduino IDE, open GRemoteFull->GRemote.bat. 
+5. Close Arduino IDE, open software->GRemoteFull->GRemote.bat (or software/GRemoteFull/GRemote.sh for OSX/Linux).
 
 6. Set the COM port, then GRemote will show you the UI as follows. That all for this part.
 [![alt text](images/GRemote.jpg "Set the COM port")](https://raw.githubusercontent.com/Makeblock-official/XY-Plotter-2.0/master/images/GRemote.jpg)

--- a/software/GRemoteFull/GRemote.sh
+++ b/software/GRemoteFull/GRemote.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+JAVA_BIN=`which java`
+if [ $? -ne 0 ]; then
+   echo "Please install java to run GRemote"
+   exit 1
+fi
+
+$JAVA_BIN -Djava.ext.dirs=lib -Djava.library.path=lib GRemote


### PR DESCRIPTION
This adds a startup script and documentation in order to start
GRemoteFull under Linux and OSX.

This doesn't rely on the delivered Java version in the repo. It expects
the Java binary in $PATH.

Signed-off-by: Marc Koderer <marc@koderer.com>